### PR TITLE
Update gitmodules so that there is a distinct TurkeyRun2025 website from the 2024 one.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: gitsubmodule
     schedule:
         interval: "daily"
-    directory: /
+    directory: /events/TurkeyRun2025

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "events/TurkeyRun2024"]
 	path = events/TurkeyRun2024
 	url = https://github.com/jvermaas/turkeyrun.git
+[submodule "events/TurkeyRun2025"]
+	path = events/TurkeyRun2025
+	url = https://github.com/jvermaas/turkeyrun.git


### PR DESCRIPTION
Hi Mike, I *think* this is what we need to do to add a distinct TurkeyRun2025 event. I'm also pretty sure that dependabot will now look for changes and only apply them to the new event, but I'm less sure about that.